### PR TITLE
Added basic framework for server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,5 @@ server_run: server_build client_build server_run_only
 server_run_dev: server_build_only server_run_only
 server_test:
 	go test -v dp3/pkg/api
+
+.PHONY: pre-commit deps

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ pre-commit: .git/hooks/pre-commit
 .git/hooks/pre-commit: /usr/local/bin/pre-commit
 	pre-commit install
 
+deps: pre-commit client_deps server_deps
+
 client_deps:
 	cd client && \
 	yarn install

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 NAME = ppp
+export GOPATH = $(CURDIR)/server
+export GOBIN = $(GOPATH)/bin
 
 # This target ensures that the pre-commit hook is installed and kept up to date
 # if pre-commit updates.
@@ -17,3 +19,21 @@ client_run_dev:
 	yarn start
 client_run: client_run_dev
 
+glide_update:
+	cd server/src/dp3 && glide update
+server_deps:
+	cd server/src/dp3 && glide install
+server_build_only:
+	cd server/src/dp3/cmd/webserver && \
+	go install
+server_build: server_deps server_build_only
+server_run_only:
+	./server/bin/webserver \
+		-entry client/build/index.html \
+		-static client/build/static \
+		-port :8080 \
+		-debug_logging
+server_run: server_build client_build server_run_only
+server_run_dev: server_build_only server_run_only
+server_test:
+	go test -v dp3/pkg/api

--- a/README.md
+++ b/README.md
@@ -8,8 +8,28 @@ This prototype was built by a [Defense Digital Service](https://www.dds.mil/) te
 
 ## Development
 
-```bash
-brew install pre-commit
-pre-commit install
-brew install shellcheck
-```
+### Prerequisites
+
+Run `bin/prereqs` and install everything it tells you to. Then run `make deps`.
+
+### Setup: Server
+
+`make db_dev_init`: Creates the local docker postgres container and starts it running.
+
+`make db_migrate`: Runs migrate up for any new migrations. (You must run this on first setup before running `make server_run`. It depends on `db_dev_run`)
+
+`make server_run`: installs dependencies and builds both the client and the server, then runs the server.
+
+For faster development, use `make server_run_dev`. This builds and runs the server but skips updating dependences and re-building the client. Those tasks can be accomplished as needed with `make server_deps` and `make client_build`
+
+Dependencies are managed by glide. To add a new dependency:
+`GOPATH=/path/to/ProtoWebapp glide get new/dependency`
+
+### Setup: Client
+
+`make server_run`
+`make client_run_dev`
+
+The above will start the server running and starts the webpack dev server, proxied to our running go server.
+
+Dependencies are managed by yarn

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -18,8 +18,7 @@ function has() {
 has go "brew install go"
 has glide "brew install glide"
 has yarn "brew install yarn"
-has pre-commit "brew install pre-commit && pre-commit install --install-hooks"
-has terraform "brew install terraform"
+has pre-commit "brew install pre-commit && pre-commit install"
 has golint "go get -u github.com/golang/lint/golint"
 has shellcheck "brew install shellcheck"
 

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -19,7 +19,6 @@ has go "brew install go"
 has glide "brew install glide"
 has yarn "brew install yarn"
 has pre-commit "brew install pre-commit && pre-commit install"
-has golint "go get -u github.com/golang/lint/golint"
 has shellcheck "brew install shellcheck"
 
 if command -v nvm; then

--- a/bin/prereqs
+++ b/bin/prereqs
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+set -eu -o pipefail
+
+prereqs_found=true
+
+function has() {
+    local tool=$1
+    local tool_install_direction=$2
+    if [[ ! -z $(type -p "${tool}") ]]; then
+        echo "${tool} installed."
+    else
+        echo "WARNING: ${tool} not found, install via: ${tool_install_direction}"
+        prereqs_found=false
+    fi
+}
+
+has go "brew install go"
+has glide "brew install glide"
+has yarn "brew install yarn"
+has pre-commit "brew install pre-commit && pre-commit install --install-hooks"
+has terraform "brew install terraform"
+has golint "go get -u github.com/golang/lint/golint"
+has shellcheck "brew install shellcheck"
+
+if command -v nvm; then
+    echo "nvm installed"
+fi
+
+has node "test"
+
+if [[ $prereqs_found == "true" ]]; then
+    echo "OK: all prereqs found"
+else
+    echo "ERROR: some prereqs missing, please install them"
+    exit 1
+fi

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,6 @@
+# Server side exclude
+/bin/
+/pkg/
+/src/*
+!/src/dp3
+/src/dp3/vendor/

--- a/server/docs/adr/0000-server-framework.md
+++ b/server/docs/adr/0000-server-framework.md
@@ -1,0 +1,63 @@
+# Use Truss' [golang](https://golang.org/) web server skeleton to build API for dp3
+
+The Personal Property Prototype project needs an API and services in place to support
+
+1. The React [client](../../client/README.md) application
+1. Integration from Transport Service Providers (TSPs) who want to service the moves
+
+Because of 2. above the API will need to be fully documented, secured and readily accessible from a variety of client applications
+
+## Considered Alternatives
+
+* Using [gRpc](https://grpc.io/) as a way of publishing the APIs
+* Using [OpenAPI](https://www.openapis.org/) within the framework of a [Buffalo](https://gobuffalo.io/) golang application
+* Using [OpenAPI](https://www.openapis.org/) within the framework of a custom golang application
+* Using [Aws Lambda](https://aws.amazon.com/lambda/) to host a 'serverless' API
+* Using another language and web framework, e.g. Python/Django, Ruby/Rails or Phoenix/Elixir
+
+## Decision Outcome
+
+* Chosen Alternative: Using OpenAPI within the context of a custom golang application
+* Golang is a fairly straightforward choice for the implementation language bringing together Type safety, Active support and development, and enough community experience to be relatively low risk
+* gRpc is not (yet) well suited to Web applications (see below) so was ruled out by our need to support the React client
+* Buffalo brought too many 'opinions'/baggage in terms of web pipeline, lack of support for React out of the box
+* Lambda is very tempting for simplifying deployment and management, but has too many unknowns for the team in terms of cost and performance.
+
+* Consequence: need to rapidly evaluate OpenAPI code generation tools and test/confirm the belief that they can be intergrated into our application framework
+
+## Pros and Cons of the Alternatives
+
+### [gRpc](https://grpc.io/)
+
+* `+` High performance RPC mechanism with active support from google
+* `-` gRpc doesn't currently have good [support for web clients](https://improbable.io/games/blog/grpc-web-moving-past-restjson-towards-type-safe-web-apis) and while Improbable is driving this and has a solution, there is no official implementation yet.
+
+### [OpenAPI](https://www.openapis.org/) within the framework of a [Buffalo](https://gobuffalo.io)
+
+* `+` Buffalo is the most complete golang web framework we have found and pulls together solutions to most of the commong web framework concerns (authentication, authorization, middleware injection, database management and mapping)
+* `+` It has an active community supporting it
+* `-` The built in web pipeline does not (out of the box) have support for a React pipeline, and in particular the Create React App framework.
+* `-` Adapting the framework to accomodate out client work would undermine many of the benefits of using an off the shelf web framework without mitigating any of the dependecy risks
+* `-` It is not clear how OpenAPI code generation tools might co-exist with the buffalo framework
+
+### [OpenAPI](https://www.openapis.org/) within the framework of a custom golang application
+
+* `+` Truss has already done most of the preparatory work for this in our Prototype Web Application
+* `+` We have control of a known codebase
+* `-` It is not clear how best to intergrate OpenAPI code generation tools into our current workflow.
+* `-` We need to manage the evaluation, selection and integration of all the parts of the system, e.g. [authentication](https://github.com/markbates/goth), [database management](https://github.com/markbates/pop) etc
+
+### [Aws Lambda](https://aws.amazon.com/lambda/)
+
+* `+` Is GovCloud approved and so requires no extra work if we need to operate in that environment
+* `+` Removes the need for server infrastructure.
+* `-` Pricing can be a suprise as it is based on traffic (according to anecdata from people Truss has asked)
+* `-` We have no experience building this way so it carries risks of longer dev ramp up and potential performance/reliability suprises.
+
+### Other languages/web frameworks
+
+* `+` Some team members are more familiar with, e.g. Django or Rails
+* `+` Some frameworks have more longjevity in the field
+* `-` Django and Rails are less compelling in a single-page responsive client app environment
+* `-` Type safety has repeatedly shown
+* `-` React/go is what was proposed, with good reason, during the bid process for this contract. Adopting another approach without a compelling reason seems contrary.

--- a/server/docs/adr/README.md
+++ b/server/docs/adr/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/server/docs/adr/index.md
+++ b/server/docs/adr/index.md
@@ -1,0 +1,14 @@
+# Architectural Decision Log
+
+This log lists the architectural decisions for DP3 Infrastructure.
+
+<!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->
+
+- [ADR-0000](0000-server-framework.md) - Use Truss' [golang](https://golang.org/) web server skeleton to build API for dp3
+
+<!-- adrlogstop -->
+
+For new ADRs, please use [template.md](template.md).
+
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/server/docs/adr/template.md
+++ b/server/docs/adr/template.md
@@ -1,0 +1,42 @@
+# *[short title of solved problem and solution]*
+
+**User Story:** *[ticket/issue-number]* <!-- optional -->
+
+*[context and problem statement]*
+*[decision drivers | forces]* <!-- optional -->
+
+## Considered Alternatives
+
+* *[alternative 1]*
+* *[alternative 2]*
+* *[alternative 3]*
+* *[...]* <!-- numbers of alternatives can vary -->
+
+## Decision Outcome
+
+* Chosen Alternative: *[alternative 1]*
+* *[justification. e.g., only alternative, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)]*
+* *[consequences. e.g., negative impact on quality attribute, follow-up decisions required, ...]* <!-- optional -->
+
+## Pros and Cons of the Alternatives <!-- optional -->
+
+### *[alternative 1]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 2]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->
+
+### *[alternative 3]*
+
+* `+` *[argument 1 pro]*
+* `+` *[argument 2 pro]*
+* `-` *[argument 1 con]*
+* *[...]* <!-- numbers of pros and cons can vary -->

--- a/server/src/dp3/cmd/webserver/main.go
+++ b/server/src/dp3/cmd/webserver/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"dp3/pkg/api"
+	"flag"
+	"go.uber.org/zap"
+	"goji.io"
+	"goji.io/pat"
+	"log"
+	"net/http"
+)
+
+var logger *zap.Logger
+
+// TODO(nick - 12/21/17) - this is a simple logger for debugging testing
+// It needs replacing with something we can use in production
+func requestLogger(h http.Handler) http.Handler {
+	zap.L().Info("Request logger installed")
+	wrapper := func(w http.ResponseWriter, r *http.Request) {
+		zap.L().Info("Request", zap.String("url", r.URL.String()))
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(wrapper)
+}
+
+func main() {
+
+	entry := flag.String("entry", "../client/build/index.html", "the entrypoint to serve.")
+	static := flag.String("static", "../client/build/static", "the directory to serve static files from.")
+	port := flag.String("port", ":8080", "the `port` to listen on.")
+	debugLogging := flag.Bool("debug_logging", false, "log messages at the debug level.")
+	flag.Parse()
+
+	// Set up logger for the system
+	var err error
+	if *debugLogging {
+		logger, err = zap.NewDevelopment()
+	} else {
+		logger, err = zap.NewProduction()
+	}
+	if err != nil {
+		log.Fatalf("Failed to initialize Zap logging due to %v", err)
+	}
+	zap.ReplaceGlobals(logger)
+
+	// api routes
+	api := api.Mux()
+
+	// Base routes
+	root := goji.NewMux()
+	root.Handle(pat.New("/api/*"), api)
+	root.Handle(pat.Get("/static/*"),
+		http.StripPrefix("/static", http.FileServer(http.Dir(*static))))
+	root.HandleFunc(pat.Get("/*"), IndexHandler(entry))
+
+	// And request logging
+	root.Use(requestLogger)
+
+	zap.L().Info("Starting the server listening", zap.String("port", *port))
+	http.ListenAndServe(*port, root)
+}
+
+// IndexHandler serves up our index.html
+func IndexHandler(entrypoint *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, *entrypoint)
+	}
+}

--- a/server/src/dp3/glide.lock
+++ b/server/src/dp3/glide.lock
@@ -1,0 +1,21 @@
+hash: 6667f29f160cb8fee8fa4de9e8e824832685faad7ea04fdd515ace0cae857b21
+updated: 2017-12-20T16:48:36.017412-08:00
+imports:
+- name: go.uber.org/atomic
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+- name: go.uber.org/zap
+  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
+- name: goji.io
+  version: 0d89ff54b2c18c9c4ba530e32496aef902d3c6cd
+  subpackages:
+  - internal
+  - pat
+  - pattern
+testImports: []

--- a/server/src/dp3/glide.yaml
+++ b/server/src/dp3/glide.yaml
@@ -1,0 +1,4 @@
+package: protowebapp
+import:
+- package: goji.io
+- package: go.uber.org/zap

--- a/server/src/dp3/pkg/api/api.go
+++ b/server/src/dp3/pkg/api/api.go
@@ -20,12 +20,12 @@ func Mux() *goji.Mux {
 	return apiMux
 }
 
-// Greeting represents a greeting
+// Incoming body for POST /issues
 type issue struct {
 	Issue string `json:"issue"`
 }
 
-// Message is a message.
+// Response to POST /issues
 type newIssueResponse struct {
 	ID int64 `json:"id"`
 }

--- a/server/src/dp3/pkg/api/api.go
+++ b/server/src/dp3/pkg/api/api.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"encoding/json"
+	"go.uber.org/zap"
+	"goji.io"
+	"goji.io/pat"
+	"net/http"
+)
+
+// Mux creates the API router and returns it for inclusion in the app router
+func Mux() *goji.Mux {
+
+	apiMux := goji.SubMux()
+
+	version1Mux := goji.SubMux()
+	version1Mux.HandleFunc(pat.Post("/issues"), submitIssueHandler)
+	apiMux.Handle(pat.New("/v1/*"), version1Mux)
+
+	return apiMux
+}
+
+// Greeting represents a greeting
+type issue struct {
+	Issue string `json:"issue"`
+}
+
+// Message is a message.
+type newIssueResponse struct {
+	ID int64 `json:"id"`
+}
+
+func submitIssueHandler(w http.ResponseWriter, r *http.Request) {
+	var newIssue issue
+
+	if err := json.NewDecoder(r.Body).Decode(&newIssue); err != nil {
+		zap.L().Error("Json decode", zap.Error(err))
+		http.Error(w, http.StatusText(400), http.StatusBadRequest)
+	} else {
+		resp := newIssueResponse{1}
+		responseJSON, err := json.Marshal(resp)
+
+		if err != nil {
+			zap.L().Error("Encode message", zap.Error(err))
+			http.Error(w, http.StatusText(500), http.StatusInternalServerError)
+		} else {
+			w.Write(responseJSON)
+		}
+	}
+}

--- a/server/src/dp3/pkg/api/api_test.go
+++ b/server/src/dp3/pkg/api/api_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSubmitIssueHandler(t *testing.T) {
+	newIssue := issue{"This is a test issue. The tests are not working. 🍏🍎😍"}
+
+	body, err := json.Marshal(newIssue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", "/issues", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(submitIssueHandler)
+	handler.ServeHTTP(rr, req)
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is what we expect.
+	var response newIssueResponse
+	err = json.NewDecoder(rr.Body).Decode(&response)
+	if err != nil {
+		t.Errorf("Failed to decode submitIssueResponse response - %s", err)
+	}
+}


### PR DESCRIPTION
Added basic framework for the go-lang server which will server the website and API requests.

At the moment, there is only one API endpoint

`POST /api/v1/issues`

which expects a JSON body of the form

```
{
    "issue": "Issue text - some text to add to the ....."
}
```

the response, if successful, with be of the form

```
{
    "id": n
}
``` 

where `n` is an  integer identifier for the newly added item. This endpoint is simply a placeholder at the moment and will change as we progress.

