### PR TITLE
add make client_test to ci build to test issues with interactivity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           paths:
             - ~/.cache/pre-commit
       - run: make client_build
+      - run: make client_test
       - run: make server_test
       - run: make server_build_docker
       - run:

--- a/client/src/scenes/Feedback/Feedback.test.js
+++ b/client/src/scenes/Feedback/Feedback.test.js
@@ -12,5 +12,5 @@ it('renders without crashing', () => {
 test('it should change state when provided a key and value', () => {
   const wrapper = shallow(<Feedback />);
   wrapper.instance().handleChange({ target: { value: 'test text' } });
-  expect(wrapper.instance().state.value).toEqual('dogs r cute');
+  expect(wrapper.instance().state.value).toEqual('test text');
 });

--- a/client/src/scenes/Feedback/Feedback.test.js
+++ b/client/src/scenes/Feedback/Feedback.test.js
@@ -12,5 +12,5 @@ it('renders without crashing', () => {
 test('it should change state when provided a key and value', () => {
   const wrapper = shallow(<Feedback />);
   wrapper.instance().handleChange({ target: { value: 'test text' } });
-  expect(wrapper.instance().state.value).toEqual('test text');
+  expect(wrapper.instance().state.value).toEqual('dogs r cute');
 });


### PR DESCRIPTION
To address https://www.pivotaltracker.com/story/show/154409771 regarding whether there's an issue with running yarn tests (interactive) in CI. Travis by default sets CI=True according to their documentation, which should make the yarn tests NOT interactive. I'm testing here to see if the behavior is as expected.